### PR TITLE
add headers subcommand to the CLI (#96)

### DIFF
--- a/cmd/llvm-obfuscator/cli/obfuscate.py
+++ b/cmd/llvm-obfuscator/cli/obfuscate.py
@@ -606,6 +606,78 @@ def jotai(
     except Exception as exc:
         logger.error("Jotai benchmark failed: %s", exc)
         raise typer.Exit(code=1)
+    
+@app.command()
+def headers(
+    input_file: Path = typer.Argument(..., help="C/C++ source file to obfuscate"),
+    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file (default: input_obfuscated.c)"),
+    stdlib_only: bool = typer.Option(False, "--stdlib-only", help="Obfuscate only standard library functions"),
+    custom_only: bool = typer.Option(False, "--custom-only", help="Obfuscate only custom functions"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be obfuscated without writing output"),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show function pointer mapping"),
+):
+    """Obfuscate function calls in a C/C++ source file using indirect calls via function pointers."""
+
+    from core.indirect_call_obfuscator import obfuscate_indirect_calls
+
+    if not input_file.exists():
+        typer.echo(f"Error: Input file not found: {input_file}", err=True)
+        raise typer.Exit(code=1)
+    
+    output_file = output or input_file.parent / f"{input_file.stem}_obfuscated{input_file.suffix}"
+
+    if stdlib_only:
+        obfuscate_stdlib = True
+        obfuscate_custom = False
+    elif custom_only:
+        obfuscate_stdlib = False
+        obfuscate_custom = True
+    else:
+        obfuscate_stdlib = True
+        obfuscate_custom = True
+
+    typer.echo(f"📄 Reading: {input_file}")
+    source_code = input_file.read_text(encoding="utf-8", errors="replace")
+
+    typer.echo("🔒 Obfuscating function calls...")
+    typer.echo(f"   - Standard library: {'Yes' if obfuscate_stdlib else 'No'}")
+    typer.echo(f"   - Custom functions: {'Yes' if obfuscate_custom else 'No'}")
+
+    try:
+        transformed_code, metadata = obfuscate_indirect_calls(
+            source_code,
+            input_file,
+            obfuscate_stdlib=obfuscate_stdlib,
+            obfuscate_custom=obfuscate_custom,
+        )
+
+        typer.echo("\n✅ Obfuscation complete:")
+        typer.echo(f"   - Standard library functions: {metadata['obfuscated_stdlib_functions']}")
+        typer.echo(f"   - Custom functions: {metadata['obfuscated_custom_functions']}")
+        typer.echo(f"   - Total obfuscated: {metadata['total_obfuscated']}")
+
+        if verbose:
+            typer.echo("\n📋 Function pointers created:")
+            for func, ptr in sorted(metadata["function_pointers"].items()):
+                typer.echo(f"   {func} → {ptr}")
+
+        if dry_run:
+            typer.echo("\n Dry run mode - no file written")
+            typer.echo("\n Preview (first 50 lines):")
+            typer.echo("=" * 60)
+            for i, line in enumerate(transformed_code.split("\n")[:50], 1):
+                typer.echo(f"{i:3}: {line}")
+            typer.echo("=" * 60)
+        else:
+            output_file.write_text(transformed_code, encoding="utf-8")
+            typer.echo(f"\n💾 Output written to: {output_file}")
+
+    except Exception as exc:
+        typer.echo(f"\n❌ Error during obfuscation: {exc}", err=True)
+        if verbose:
+            import traceback
+            traceback.print_exc()
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/cmd/llvm-obfuscator/tests/test_obfuscate_headers.py
+++ b/cmd/llvm-obfuscator/tests/test_obfuscate_headers.py
@@ -1,0 +1,217 @@
+"""
+Tests for the indirect call obfuscation logic used by obfuscate_headers.py.
+
+obfuscate_headers.py is just a CLI wrapper — the real work happens in
+core/indirect_call_obfuscator.py via obfuscate_indirect_calls().
+
+I test three flows mentioned in the issue:
+  - stdlib-only  (--stdlib-only flag)
+  - custom-only  (--custom-only flag)
+  - dry-run      (metadata is correct even when no file is written)
+
+Plus a couple of edge cases so regressions are caught early.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from core.indirect_call_obfuscator import obfuscate_indirect_calls
+
+
+# Small C snippets used as inputs across the tests
+
+STDLIB_SOURCE = """\
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    printf("hello\\n");
+    int *p = (int *)malloc(64);
+    memset(p, 0, 64);
+    free(p);
+    return 0;
+}
+"""
+
+CUSTOM_SOURCE = """\
+#include <stdio.h>
+
+int add(int a, int b) {
+    return a + b;
+}
+
+void greet(const char *name) {
+    printf("hi %s\\n", name);
+}
+
+int main(void) {
+    int result = add(1, 2);
+    greet("world");
+    return result;
+}
+"""
+
+MIXED_SOURCE = """\
+#include <stdio.h>
+#include <string.h>
+
+int helper(const char *s) {
+    return strlen(s);
+}
+
+int main(void) {
+    printf("len=%d\\n", helper("test"));
+    return 0;
+}
+"""
+
+
+# --- stdlib-only flow ---
+# This is what happens when you run: obfuscate_headers.py input.c --stdlib-only
+
+def test_stdlib_only_obfuscates_stdlib_functions(tmp_path):
+    # should obfuscate printf, malloc, free, memset — all stdlib calls in the source
+    _, meta = obfuscate_indirect_calls(
+        STDLIB_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=True, obfuscate_custom=False
+    )
+    assert meta["obfuscated_stdlib_functions"] > 0
+
+
+def test_stdlib_only_does_not_touch_custom_functions(tmp_path):
+    # with --stdlib-only, custom function count must stay 0
+    _, meta = obfuscate_indirect_calls(
+        STDLIB_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=True, obfuscate_custom=False
+    )
+    assert meta["obfuscated_custom_functions"] == 0
+
+
+def test_stdlib_only_total_matches_stdlib_count(tmp_path):
+    _, meta = obfuscate_indirect_calls(
+        STDLIB_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=True, obfuscate_custom=False
+    )
+    assert meta["total_obfuscated"] == meta["obfuscated_stdlib_functions"]
+
+
+def test_stdlib_only_pointer_names_follow_naming_convention(tmp_path):
+    # the obfuscator names pointers as __fptr_<funcname>
+    _, meta = obfuscate_indirect_calls(
+        STDLIB_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=True, obfuscate_custom=False
+    )
+    for fn, ptr in meta["function_pointers"].items():
+        assert ptr == f"__fptr_{fn}"
+
+
+def test_stdlib_only_direct_calls_replaced_in_output(tmp_path):
+    # after obfuscation, printf( should be gone and __fptr_printf( should appear
+    transformed, _ = obfuscate_indirect_calls(
+        STDLIB_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=True, obfuscate_custom=False
+    )
+    assert "__fptr_printf(" in transformed
+    assert len(re.findall(r'\bprintf\s*\(', transformed)) == 0
+
+
+# --- custom-only flow ---
+# This is what happens when you run: obfuscate_headers.py input.c --custom-only
+
+def test_custom_only_obfuscates_custom_functions(tmp_path):
+    _, meta = obfuscate_indirect_calls(
+        CUSTOM_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=False, obfuscate_custom=True
+    )
+    assert meta["obfuscated_custom_functions"] > 0
+
+
+def test_custom_only_does_not_touch_stdlib(tmp_path):
+    _, meta = obfuscate_indirect_calls(
+        CUSTOM_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=False, obfuscate_custom=True
+    )
+    assert meta["obfuscated_stdlib_functions"] == 0
+
+
+def test_custom_only_detected_add_and_greet(tmp_path):
+    # CUSTOM_SOURCE defines add() and greet(), both should appear in the pointer map
+    _, meta = obfuscate_indirect_calls(
+        CUSTOM_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=False, obfuscate_custom=True
+    )
+    assert "add" in meta["function_pointers"]
+    assert "greet" in meta["function_pointers"]
+
+
+def test_custom_only_main_is_not_obfuscated(tmp_path):
+    # main() should never be treated as a custom function to obfuscate
+    _, meta = obfuscate_indirect_calls(
+        CUSTOM_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=False, obfuscate_custom=True
+    )
+    assert "main" not in meta["function_pointers"]
+
+
+def test_custom_only_calls_replaced_in_output(tmp_path):
+    transformed, _ = obfuscate_indirect_calls(
+        CUSTOM_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=False, obfuscate_custom=True
+    )
+    assert "__fptr_add(" in transformed
+
+
+# --- dry-run flow ---
+# When --dry-run is used, obfuscate_headers.py calls obfuscate_indirect_calls()
+# normally but skips writing the file. So the metadata must be fully correct
+# for the preview/display to make sense.
+
+def test_dryrun_metadata_is_complete(tmp_path):
+    # all keys the CLI reads for dry-run display must be present
+    _, meta = obfuscate_indirect_calls(STDLIB_SOURCE, tmp_path / "t.c")
+    assert "obfuscated_stdlib_functions" in meta
+    assert "obfuscated_custom_functions" in meta
+    assert "total_obfuscated" in meta
+    assert "function_pointers" in meta
+
+
+def test_dryrun_transformed_code_is_valid_for_preview(tmp_path):
+    # the CLI prints the first 50 lines of transformed_code in dry-run mode
+    transformed, _ = obfuscate_indirect_calls(STDLIB_SOURCE, tmp_path / "t.c")
+    lines = transformed.split("\n")
+    assert len(lines) >= 1 and any(line.strip() for line in lines)
+
+
+def test_dryrun_function_pointers_can_be_sorted_and_printed(tmp_path):
+    # the CLI does: for func, ptr in sorted(metadata['function_pointers'].items())
+    _, meta = obfuscate_indirect_calls(STDLIB_SOURCE, tmp_path / "t.c")
+    items = sorted(meta["function_pointers"].items())
+    assert all(isinstance(fn, str) and isinstance(ptr, str) for fn, ptr in items)
+
+
+# --- edge cases ---
+
+def test_empty_source_gives_zero_counts(tmp_path):
+    _, meta = obfuscate_indirect_calls("", tmp_path / "t.c")
+    assert meta["total_obfuscated"] == 0
+    assert meta["function_pointers"] == {}
+
+
+def test_source_with_no_known_calls_gives_zero_total(tmp_path):
+    source = "#include <stdio.h>\n\nint x = 42;\n"
+    _, meta = obfuscate_indirect_calls(source, tmp_path / "t.c")
+    assert meta["total_obfuscated"] == 0
+
+
+def test_total_is_sum_of_stdlib_and_custom(tmp_path):
+    # sanity check: total must always equal the two sub-counts added together
+    _, meta = obfuscate_indirect_calls(
+        MIXED_SOURCE, tmp_path / "t.c",
+        obfuscate_stdlib=True, obfuscate_custom=True
+    )
+    assert meta["total_obfuscated"] == (
+        meta["obfuscated_stdlib_functions"] + meta["obfuscated_custom_functions"]
+    )


### PR DESCRIPTION
## What this PR does
Adds a new `headers` subcommand to the main CLI so that the 
obfuscate_headers.py functionality is discoverable alongside 
other commands like `compile`, `analyze`, and `compare`.

## How to use it
# Obfuscate both stdlib and custom functions
python -m cli.obfuscate headers input.c

# Obfuscate only stdlib functions (printf, malloc etc.)
python -m cli.obfuscate headers input.c --stdlib-only

# Obfuscate only custom functions
python -m cli.obfuscate headers input.c --custom-only

# Preview what would be obfuscated without writing any file
python -m cli.obfuscate headers input.c --dry-run

# Show the function pointer mapping
python -m cli.obfuscate headers input.c --verbose

## Changes
- Added `headers` command to `cmd/llvm-obfuscator/cli/obfuscate.py`
- Exposes the same options as the standalone script (--stdlib-only, 
  --custom-only, --dry-run, --verbose)

Closes #96